### PR TITLE
Fix an overlap in rules sentence_assign & sentence_assign_contour

### DIFF
--- a/sc-memory/sc-memory/scs/scs.g4
+++ b/sc-memory/sc-memory/scs/scs.g4
@@ -152,7 +152,7 @@ sentence_assign
   ;
 
 sentence_assign_contour
-  : a=idtf_common '=' i=contourWithJoin
+  : a=idtf_system '=' i=contourWithJoin
     {
       m_parser->ProcessContourEndWithJoin($ctx->a->handle);
     }


### PR DESCRIPTION
Remove ambiguity for assigning an alias to a contour `@a = [* ... *];;` where previously both rules could be applied.