### PR TITLE
[sc-memory] Implement highly dependent edges template build logic

### DIFF
--- a/sc-memory/sc-memory/sc_template_build.cpp
+++ b/sc-memory/sc-memory/sc_template_build.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <utility>
 
 namespace
 {
@@ -17,28 +18,16 @@ namespace
 class ObjectInfo
 {
 public:
-  ObjectInfo(ScAddr const & inAddr, ScType const & inType, std::string const & inSysIdtf)
+  ObjectInfo(ScAddr const & inAddr, ScType const & inType, std::string inSysIdtf)
     : m_addr(inAddr)
     , m_type(inType)
-    , m_sysIdtf(inSysIdtf)
-    , m_source(nullptr)
-    , m_target(nullptr)
+    , m_sysIdtf(std::move(inSysIdtf))
   {
   }
 
   inline bool IsEdge() const
   {
     return m_type.IsEdge();
-  }
-
-  inline ObjectInfo const * GetSource() const
-  {
-    return m_source;
-  }
-
-  inline ObjectInfo const * GetTarget() const
-  {
-    return m_target;
   }
 
   inline ScAddr const & GetAddr() const
@@ -56,93 +45,20 @@ public:
     return m_type;
   }
 
-  inline void SetSource(ObjectInfo * src)
-  {
-    m_source = src;
-  }
-
-  inline void SetTarget(ObjectInfo * trg)
-  {
-    m_target = trg;
-  }
-
-  inline uint32_t CalculateEdgeRank() const
-  {
-    SC_ASSERT(IsEdge(), ());
-    SC_ASSERT(m_source, ());
-    SC_ASSERT(m_target, ());
-    return (m_source->GetType().IsConst() ? 1 : 0) +
-           (m_target->GetType().IsConst() ? 1 : 0);
-  }
-
 private:
   ScAddr m_addr;
   ScType m_type;
   std::string m_sysIdtf;
-
-  // edge data
-  ObjectInfo * m_source;
-  ObjectInfo * m_target;
 };
 
-class EdgeLessFunctor
-{
-  using EdgeDependMap = std::unordered_multimap<ScAddr::HashType, ScAddr::HashType>;
-  using ObjectVector = std::vector<ObjectInfo>;
-
-public:
-  explicit EdgeLessFunctor(EdgeDependMap const & edgeDependMap, ObjectVector const & objects)
-    : m_edgeDependMap(edgeDependMap)
-    , m_objects(objects)
-  {
-  }
-
-  // returns true, when edge srouce/target objects depend on otherEdge construction
-  bool IsEdgeDependOnOther(ScAddr::HashType const & edge, ScAddr::HashType const & otherEdge) const
-  {
-    // TODO: support possible loops
-    auto const range = m_edgeDependMap.equal_range(edge);
-    for (auto it = range.first; it != range.second; ++it)
-    {
-      if (it->second || IsEdgeDependOnOther(it->second, otherEdge))
-        return true;
-    }
-
-    return false;
-  }
-
-  bool operator() (size_t const indexA, size_t const indexB) const
-  {
-    ObjectInfo const & objA = m_objects[indexA];
-    ObjectInfo const & objB = m_objects[indexB];
-
-    SC_ASSERT(objA.IsEdge(), ());
-    SC_ASSERT(objB.IsEdge(), ());
-
-    if (IsEdgeDependOnOther(objA.GetAddr().Hash(), objB.GetAddr().Hash()))
-      return false;
-    else if (IsEdgeDependOnOther(objB.GetAddr().Hash(), objA.GetAddr().Hash()))
-      return true;
-
-    uint32_t const rankA = objA.CalculateEdgeRank();
-    uint32_t const rankB = objB.CalculateEdgeRank();
-
-    if (rankA != rankB)
-      return rankA > rankB;
-
-    return objA.GetAddr().Hash() < objB.GetAddr().Hash();
-  }
-
-private:
-  EdgeDependMap const & m_edgeDependMap;
-  ObjectVector const & m_objects;
-};
-
-} // namespace
+}
 
 class ScTemplateBuilder
 {
   friend class ScTemplate;
+  using EdgeDependMap = std::unordered_multimap<ScAddr::HashType, ScAddr::HashType>;
+  using ObjectToIdtfMap = std::map<ScAddr::HashType, ObjectInfo>;
+  using ScAddrHashVector = std::vector<ScAddr::HashType>;
 
 protected:
   ScTemplateBuilder(
@@ -161,168 +77,187 @@ protected:
     inTemplate->m_isForceOrder = false;
 
     // TODO: add struct blocking
-    // TODO: provide error codes
-    std::unordered_map<ScAddr::HashType, size_t> addrToObjectIndex;
-    std::unordered_multimap<ScAddr::HashType, ScAddr::HashType> edgeDependMap;
-    std::vector<size_t> edgeIndices;
-
-    m_objects.reserve(1024);
-    edgeIndices.reserve(512);
+    ScAddrHashVector independentEdges;
+    independentEdges.reserve(512);
 
     size_t index = 0;
-
     ScIterator3Ptr iter = m_context.Iterator3(
           m_templateAddr,
           *ScType::EdgeAccessConstPosPerm,
           *ScType());
 
+    // define edges set and independent edges set
     while (iter->Next())
     {
       ScAddr const objAddr = iter->Get(2);
-      ScAddr::HashType const objHash = objAddr.Hash();
-
-      auto const it = addrToObjectIndex.find(objHash);
-      if (it != addrToObjectIndex.end())
-        continue; // object already exist
-      addrToObjectIndex[objHash] = m_objects.size();
-
-      ScType const objType = m_context.GetElementType(objAddr);
-      if (objType.IsUnknown())
-        return ScTemplate::Result(false, "Can't determine type of ScElement"); // template corrupted
-
       std::string objIdtf = m_context.HelperGetSystemIdtf(objAddr);
+
       if (objIdtf.empty())
-        objIdtf = "..obj_" + std::to_string(index++);
-
-      if (objType.IsEdge())
-        edgeIndices.emplace_back(m_objects.size());
-
-      m_objects.emplace_back(objAddr, objType, objIdtf);
-    }
-
-    // iterate all edges and determine source/target objects
-    for (auto const i : edgeIndices)
-    {
-      ObjectInfo & obj = m_objects[i];
-
-      // determine source and target objects
-      ScAddr src, trg;
-      if (!m_context.GetEdgeInfo(obj.GetAddr(), src, trg))
-        return ScTemplate::Result(false, "Edge removed during parse"); // edge already doesn't exist
-
-      auto const itSrc = addrToObjectIndex.find(src.Hash());
-      if (itSrc == addrToObjectIndex.end())
-        return ScTemplate::Result(false, "Edge source removed during parse");; // edge source doesn't exist in template
-
-      auto const itTrg = addrToObjectIndex.find(trg.Hash());
-      if (itTrg == addrToObjectIndex.end())
-        return ScTemplate::Result(false, "Edge target removed during parse");; // target source doesn't exist in template
-
-      ObjectInfo * srcObj = &(m_objects[itSrc->second]);
-      ObjectInfo * trgObj = &(m_objects[itTrg->second]);
-
-      if (srcObj->IsEdge())
-        edgeDependMap.insert({ obj.GetAddr().Hash(), srcObj->GetAddr().Hash() });
-      if (trgObj->IsEdge())
-        edgeDependMap.insert({ obj.GetAddr().Hash(), srcObj->GetAddr().Hash() });
-
-      obj.SetSource(srcObj);
-      obj.SetTarget(trgObj);
-    }
-
-    // now need to sort edges for suitable search order
-    std::sort(edgeIndices.begin(), edgeIndices.end(), EdgeLessFunctor(edgeDependMap, m_objects));
-
-    // build template
-    {
-      for (auto const i : edgeIndices)
       {
-        ObjectInfo const & edge = m_objects[i];
-        SC_ASSERT(edge.GetType().IsVar(), ());
+        objIdtf = "..obj_" + std::to_string(index++);
+      }
 
-        ObjectInfo const src = replaceWithParam(edge.GetSource());
-        ObjectInfo const trg = replaceWithParam(edge.GetTarget());
+      ScAddr::HashType const objHash = objAddr.Hash();
+      ScType const objType = m_context.GetElementType(objAddr);
 
-        ScType const srcType = src.GetType();
-        ScType const trgType = trg.GetType();
+      if (objType.IsUnknown())
+      {
+        return ScTemplate::Result(false, "Can't determine type of ScElement"); // template corrupted
+      }
 
-        if (srcType.IsConst())
+      m_elements.insert({objHash, ObjectInfo(objAddr, objType, objIdtf)});
+
+      ScAddr objSrc, objTrg;
+      if (objType.IsEdge() && m_context.GetEdgeInfo(objAddr, objSrc, objTrg))
+      {
+        ScType const srcType = m_context.GetElementType(objSrc),
+              trgType = m_context.GetElementType(objTrg);
+
+        if (!srcType.IsEdge() && !trgType.IsEdge())
         {
-          if (trgType.IsConst())  // F_A_F
+          auto const & it = std::find(independentEdges.begin(), independentEdges.end(), objHash);
+          if (it == independentEdges.end())
+          {
+            independentEdges.emplace_back(objHash);
+          }
+        }
+        if (srcType.IsEdge())
+        {
+          m_edgeDependenceMap.insert({objHash, objSrc.Hash()});
+        }
+        if (trgType.IsEdge())
+        {
+          m_edgeDependenceMap.insert({objHash, objTrg.Hash()});
+        }
+      }
+    }
+
+    // split edges set by their power
+    std::vector<ScAddrHashVector> powerDependentEdges;
+    powerDependentEdges.emplace_back(independentEdges);
+    size_t size = powerDependentEdges.size();
+
+    for (auto const & hPair : m_edgeDependenceMap)
+    {
+      index = GetEdgeDependencePower(hPair.first, hPair.second);
+      if (index >= powerDependentEdges.size())
+      {
+        while (size <= index)
+        {
+          powerDependentEdges.emplace_back(ScAddrHashVector());
+          size++;
+        }
+      }
+
+      auto const & equalDependentEdges = powerDependentEdges.at(index);
+      auto const & equalDependentEdgesIt = std::find(equalDependentEdges.begin(), equalDependentEdges.end(), hPair.first);
+      if (equalDependentEdgesIt == equalDependentEdges.end())
+      {
+        powerDependentEdges.at(index).emplace_back(hPair.first);
+      }
+    }
+
+    // make tuple of partitions set subsets
+    ScAddrHashVector edges;
+    edges.reserve(512);
+    for (auto const & equalDependentEdges : powerDependentEdges)
+    {
+      for (auto const & edge : equalDependentEdges)
+      {
+        edges.emplace_back(edge);
+      }
+    }
+
+    // form template
+    for (auto const i : edges)
+    {
+      ObjectInfo const & edge = m_elements.at(i);
+      SC_ASSERT(edge.GetType().IsVar(), ());
+
+      ScAddr srcAddr, trgAddr;
+      m_context.GetEdgeInfo(edge.GetAddr(), srcAddr, trgAddr);
+      ObjectInfo const src = replaceWithParam(&m_elements.at(srcAddr.Hash()));
+      ObjectInfo const trg = replaceWithParam(&m_elements.at(trgAddr.Hash()));
+
+      ScType const srcType = src.GetType();
+      ScType const trgType = trg.GetType();
+
+      if (srcType.IsConst())
+      {
+        if (trgType.IsConst())  // F_A_F
+        {
+          inTemplate->Triple(
+                src.GetAddr() >> src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trg.GetAddr() >> trg.GetIdtf());
+        }
+        else
+        {
+          if (inTemplate->HasReplacement(trg.GetIdtf())) // F_A_F
           {
             inTemplate->Triple(
                   src.GetAddr() >> src.GetIdtf(),
                   edge.GetType() >> edge.GetIdtf(),
-                  trg.GetAddr() >> trg.GetIdtf());
+                  trg.GetIdtf());
           }
-          else
+          else // F_A_A
           {
-            if (inTemplate->HasReplacement(trg.GetIdtf())) // F_A_F
-            {
-              inTemplate->Triple(
-                    src.GetAddr() >> src.GetIdtf(),
-                    edge.GetType() >> edge.GetIdtf(),
-                    trg.GetIdtf());
-            }
-            else // F_A_A
-            {
-              inTemplate->Triple(
-                    src.GetAddr() >> src.GetIdtf(),
-                    edge.GetType() >> edge.GetIdtf(),
-                    trgType >> trg.GetIdtf());
-            }
+            inTemplate->Triple(
+                  src.GetAddr() >> src.GetIdtf(),
+                  edge.GetType() >> edge.GetIdtf(),
+                  trgType >> trg.GetIdtf());
           }
         }
-        else if (trgType.IsConst())
+      }
+      else if (trgType.IsConst())
+      {
+        if (inTemplate->HasReplacement(src.GetIdtf())) // F_A_F
         {
-          if (inTemplate->HasReplacement(src.GetIdtf())) // F_A_F
-          {
-            inTemplate->Triple(
-                  src.GetIdtf(),
-                  edge.GetType() >> edge.GetIdtf(),
-                  trg.GetAddr() >> trg.GetIdtf());
-          }
-          else // A_A_F
-          {
-            inTemplate->Triple(
-                  srcType >> src.GetIdtf(),
-                  edge.GetType() >> edge.GetIdtf(),
-                  trg.GetAddr() >> trg.GetIdtf());
-          }
+          inTemplate->Triple(
+                src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trg.GetAddr() >> trg.GetIdtf());
+        }
+        else // A_A_F
+        {
+          inTemplate->Triple(
+                srcType >> src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trg.GetAddr() >> trg.GetIdtf());
+        }
+      }
+      else
+      {
+        bool const srcRepl = inTemplate->HasReplacement(src.GetIdtf());
+        bool const trgRepl = inTemplate->HasReplacement(trg.GetIdtf());
+
+        if (srcRepl && trgRepl) // F_A_F
+        {
+          inTemplate->Triple(
+                src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trg.GetIdtf());
+        }
+        else if (!srcRepl && trgRepl) // A_A_F
+        {
+          inTemplate->Triple(
+                srcType >> src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trg.GetIdtf());
+        }
+        else if (srcRepl && !trgRepl) // F_A_A
+        {
+          inTemplate->Triple(
+                src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trgType >> trg.GetIdtf());
         }
         else
         {
-          bool const srcRepl = inTemplate->HasReplacement(src.GetIdtf());
-          bool const trgRepl = inTemplate->HasReplacement(trg.GetIdtf());
-
-          if (srcRepl && trgRepl) // F_A_F
-          {
-            inTemplate->Triple(
-                  src.GetIdtf(),
-                  edge.GetType() >> edge.GetIdtf(),
-                  trg.GetIdtf());
-          }
-          else if (!srcRepl && trgRepl) // A_A_F
-          {
-            inTemplate->Triple(
-                  srcType >> src.GetIdtf(),
-                  edge.GetType() >> edge.GetIdtf(),
-                  trg.GetIdtf());
-          }
-          else if (srcRepl && !trgRepl) // F_A_A
-          {
-            inTemplate->Triple(
-                  src.GetIdtf(),
-                  edge.GetType() >> edge.GetIdtf(),
-                  trgType >> trg.GetIdtf());
-          }
-          else
-          {
-            inTemplate->Triple(
-                  srcType >> src.GetIdtf(),
-                  edge.GetType() >> edge.GetIdtf(),
-                  trgType >> trg.GetIdtf());
-          }
+          inTemplate->Triple(
+                srcType >> src.GetIdtf(),
+                edge.GetType() >> edge.GetIdtf(),
+                trgType >> trg.GetIdtf());
         }
       }
     }
@@ -336,7 +271,8 @@ protected:
   ScTemplateParams m_params;
 
   // all objects in template
-  std::vector<ObjectInfo> m_objects;
+  ObjectToIdtfMap m_elements;
+  EdgeDependMap m_edgeDependenceMap;
 
 private:
   ObjectInfo replaceWithParam(ObjectInfo const * templateItem) const
@@ -348,10 +284,37 @@ private:
       {
         ScType const type = m_context.GetElementType(replacedAddr);
         std::string const idtf = m_context.HelperGetSystemIdtf(replacedAddr);
-        return ObjectInfo(replacedAddr, type, idtf);
+        return {replacedAddr, type, idtf};
       }
     }
+
     return *templateItem;
+  }
+
+  // get edge dependence power from other edge
+  inline size_t GetEdgeDependencePower(ScAddr::HashType const & edge, ScAddr::HashType const & otherEdge) const
+  {
+    size_t max = 0;
+    DefineEdgeDependencePower(edge, otherEdge, max, 1);
+
+    return max;
+  }
+
+  // count edge dependence power from other edge
+  inline size_t DefineEdgeDependencePower(ScAddr::HashType const & edge, ScAddr::HashType const & otherEdge,
+                                          size_t & max, size_t power) const
+  {
+    auto const range = m_edgeDependenceMap.equal_range(edge);
+    for (auto it = range.first; it != range.second; ++it)
+    {
+      size_t incPower = power + 1;
+
+      if (DefineEdgeDependencePower(it->second, otherEdge, max, incPower) == incPower && power > max)
+      {
+        max = power;
+      }
+    }
+    return power;
   }
 };
 


### PR DESCRIPTION
I released new storing and sorting highly dependent edges logic. To generate structure by template dependent and independent edges choose from all of its elements, after dependent edges set divides into equivalence classes according to the maximum degree of dependence on another edge. Thus, sets of equally dependent edges are considered to be formed. After that all of them group into common tuple.
From edge to edge edge generation task (picture below) as one of the similar is solved by that algorithm.

![image](https://user-images.githubusercontent.com/56268020/135662494-85146513-b102-4dfc-a9c0-ff7a384886f6.png)

* [ ] Read PR [documentation](http://ostis-dev.github.io/sc-machine/dev/pr/)
* [ ] Update changelog
* [ ] Update documentation

